### PR TITLE
fixing bug: deleted item caused no detail page

### DIFF
--- a/matomat.py
+++ b/matomat.py
@@ -73,7 +73,10 @@ class matomat(object):
 			d={"amount":m.amount,"time":m.time.isoformat()}
 			if isinstance(m,db.Sale):
 				d["amount"]*=-1
-				d["Item"]=m.item.name
+				if m.item is not None:
+					d["Item"]=m.item.name
+				else:
+					d["Item"]='<<<Deleted Item>>>'
 			if isinstance(m,db.Transfer):
 				if m.sender==self._user:
 					d["amount"]*=-1


### PR DESCRIPTION
fixing bug which cause an empty detail page if there are items, which are deleted